### PR TITLE
Update storage paths for container root

### DIFF
--- a/.github/workflows/move_and_trigger.yml
+++ b/.github/workflows/move_and_trigger.yml
@@ -25,6 +25,7 @@ jobs:
           STORAGE_CONNECTION_STRING: ${{ secrets.STORAGE_CONNECTION_STRING }}
           TRIGGER_URL: ${{ secrets.TRIGGER_URL }}
           CONTAINER_SOURCE: kodekloudfiles
-          CONTAINER_INPUTS: kodekloud-inputs
+          CONTAINER_INPUTS: cloudkit-inputs
+          INPUT_FOLDER: input
           ARCHIVE_FOLDER: archive
         run: python scripts/move_and_trigger.py

--- a/backend/app/routers/report.py
+++ b/backend/app/routers/report.py
@@ -16,8 +16,16 @@ def create_report():
         output_excel_path = os.path.join(tmpdir, "kodekloud_report.xlsx")
         output_json_path = os.path.join(tmpdir, "kodekloud_data.json")
 
-        blob.download_blob_to_file("kodekloud-inputs", "KodeKloud2025Admin.xlsx", admin_path)
-        blob.download_blob_to_file("kodekloud-inputs", "activity_leaderboard.xlsx", activity_path)
+        blob.download_blob_to_file(
+            "cloudkit-inputs",
+            "KodeKloud2025Admin.xlsx",
+            admin_path,
+        )
+        blob.download_blob_to_file(
+            "cloudkit-inputs",
+            "activity_leaderboard.xlsx",
+            activity_path,
+        )
 
         data = generate_report.generate_report(admin_path, activity_path, output_excel_path, output_json_path)
 

--- a/backend/app/utils/generate_report.py
+++ b/backend/app/utils/generate_report.py
@@ -82,5 +82,9 @@ def generate_report(admin_path, activity_path, output_excel_path, output_json_pa
     with open(output_json_path, 'w') as f:
         json.dump(json_data, f, indent=2)
 
-    blob.upload_file_to_blob("kodekloud-inputs", output_json_path.split('/')[-1], output_json_path)
+    blob.upload_file_to_blob(
+        "cloudkit-inputs",
+        output_json_path.split('/')[-1],
+        output_json_path,
+    )
     return json_data

--- a/frontend/src/KodeKloudDashboard.jsx
+++ b/frontend/src/KodeKloudDashboard.jsx
@@ -16,7 +16,7 @@ export default function KodeKloudDashboard({ user }) {
   document.title = "Kode Kloud License Usage";
 
   const fetchData = () => {
-    fetch('https://strepamkkeast2.blob.core.windows.net/kodekloud-inputs/kodekloud_data.json?sp=r&st=2025-06-09T15:09:14Z&se=2026-02-28T23:09:14Z&sv=2024-11-04&sr=b&sig=An7b7jFr7Uh%2FnFYqoTaILe7eqw8usBFsY79QUh%2F7r2E%3D')
+    fetch('https://stcloudkitdevcus.blob.core.windows.net/cloudkit-inputs/kodekloud_data.json?sp=r&st=2025-06-09T15:09:14Z&se=2026-02-28T23:09:14Z&sv=2024-11-04&sr=b&sig=An7b7jFr7Uh%2FnFYqoTaILe7eqw8usBFsY79QUh%2F7r2E%3D')
       .then(res => {
         if (!res.ok) throw new Error(`HTTP error ${res.status}`);
         return res.json();

--- a/scripts/move_and_trigger_core.py
+++ b/scripts/move_and_trigger_core.py
@@ -6,7 +6,8 @@ from azure.storage.blob import BlobServiceClient
 # Config desde GitHub Secrets o entorno
 STORAGE_CONNECTION_STRING = os.getenv("STORAGE_CONNECTION_STRING")
 CONTAINER_SOURCE = os.getenv("CONTAINER_SOURCE", "kodekloudfiles")
-CONTAINER_INPUTS = os.getenv("CONTAINER_INPUTS", "kodekloud-inputs")
+CONTAINER_INPUTS = os.getenv("CONTAINER_INPUTS", "cloudkit-inputs")
+INPUT_FOLDER = os.getenv("INPUT_FOLDER", "input")
 ARCHIVE_FOLDER = os.getenv("ARCHIVE_FOLDER", "archive")
 TRIGGER_URL = os.getenv("TRIGGER_URL")
 
@@ -29,7 +30,7 @@ def run_my_logic():
 
     logging.info("Moviendo archivos existentes en el contenedor de entrada a /archive...")
 
-    for blob in input_container.list_blobs():
+    for blob in input_container.list_blobs(name_starts_with=f"{INPUT_FOLDER}/"):
         if blob.name.endswith(".xlsx") or blob.name.endswith(".json"):
             src = input_container.get_blob_client(blob.name)
             dst = input_container.get_blob_client(f"{ARCHIVE_FOLDER}/{blob.name}")
@@ -40,7 +41,7 @@ def run_my_logic():
 
     for filename in required_files:
         src = source_container.get_blob_client(filename)
-        dst = input_container.get_blob_client(filename)
+        dst = input_container.get_blob_client(f"{INPUT_FOLDER}/{filename}")
         dst.start_copy_from_url(src.url)
         src.delete_blob()
 


### PR DESCRIPTION
## Summary
- use the `cloudkit-inputs` container root for JSON and report files
- reserve the `input` folder for pipeline uploads
- keep workflow and scripts consistent with the new folder
- fetch dashboard JSON from the container root

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728f30f52c832bb7e58a5dc9aad69b