### PR TITLE
Implement /report/data endpoint

### DIFF
--- a/backend/app/routers/report.py
+++ b/backend/app/routers/report.py
@@ -30,3 +30,17 @@ def create_report():
         data = generate_report.generate_report(admin_path, activity_path, output_excel_path, output_json_path)
 
     return data
+
+
+@router.get("/data")
+def get_report_data():
+    """Return the latest generated JSON report from Blob Storage."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_path = os.path.join(tmpdir, "kodekloud_data.json")
+        blob.download_blob_to_file(
+            "cloudkit-inputs",
+            "kode_kloud/root/kodekloud_data.json",
+            json_path,
+        )
+        with open(json_path, "r") as f:
+            return json.load(f)

--- a/frontend/src/KodeKloudDashboard.jsx
+++ b/frontend/src/KodeKloudDashboard.jsx
@@ -16,7 +16,7 @@ export default function KodeKloudDashboard({ user }) {
   document.title = "Kode Kloud License Usage";
 
   const fetchData = () => {
-    fetch('https://stcloudkitdevcus.blob.core.windows.net/cloudkit-inputs/kodekloud_data.json?sp=r&st=2025-06-09T15:09:14Z&se=2026-02-28T23:09:14Z&sv=2024-11-04&sr=b&sig=An7b7jFr7Uh%2FnFYqoTaILe7eqw8usBFsY79QUh%2F7r2E%3D')
+    fetch('/report/data')
       .then(res => {
         if (!res.ok) throw new Error(`HTTP error ${res.status}`);
         return res.json();


### PR DESCRIPTION
## Summary
- add FastAPI endpoint to return JSON report via Azure Blob Storage
- update frontend dashboard to load data from backend endpoint

## Testing
- `npm install`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68729a6f1ab8832baee8c4978c8cea5b