### PR TITLE
Fix API 404 handling and document Docker networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ docker run -p 8080:80 kodekloud-dashboard-frontend
 
 Then visit <http://localhost:8080> in your browser to view the app.
 
+> **Note** The NGINX config proxies API requests to `http://backend:8000`. When
+> running the frontend container on its own, add a host mapping so that the name
+> `backend` resolves to your host machine where the FastAPI service is running:
+
+```bash
+docker run -p 8080:80 \
+  --add-host backend:host-gateway \
+  kodekloud-dashboard-frontend
+```
+
+Alternatively you can run both containers together using Docker Compose.
+The repository includes a `docker-compose.yml` that builds both services and
+connects them on a shared network. Simply run:
+
+```bash
+docker compose up
+```
+
+Once the containers start, open <http://localhost:8080> in your browser.
+
 ## 🔁 Triggering the Report Generation
 
 The FastAPI report endpoint can be called with:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    environment:
+      - AZURE_STORAGE_CONNECTION_STRING=${AZURE_STORAGE_CONNECTION_STRING}
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -24,6 +24,9 @@ http {
       proxy_pass http://backend:8000$request_uri;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
+      # Allow backend 4xx/5xx responses to pass through so the frontend fetch
+      # receives proper JSON errors instead of the SPA's index.html
+      proxy_intercept_errors off;
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|otf|eot)$ {


### PR DESCRIPTION
## Summary
- ensure backend 404/500 responses pass through Nginx
- document how to run frontend and backend containers together
- provide Docker Compose and backend Dockerfile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872aa0aa6f0832ba87aedbec4d47e89