### PR TITLE
Fix nginx proxy_pass to reach backend

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,7 +21,7 @@ http {
     }
 
     location /report/ {
-      proxy_pass http://backend:8000$request_uri;
+      proxy_pass http://backend:8000;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       # Allow backend 4xx/5xx responses to pass through so the frontend fetch


### PR DESCRIPTION
## Summary
- update `frontend/nginx.conf` so `proxy_pass` doesn't append `$request_uri`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872b60086e4832bacde92f2c18aa285