### PR TITLE
Remove deprecated environment example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,0 @@
-AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=stcloudkitdevcus;AccountKey=wLQeI8U3aSX8cd0Yo+I+ay4guYE65R7DIxvpK9o8EAnoisdtNE/tlTSBDAB81KwrKmCY+OWCpIXQ+AStETeI4g==;EndpointSuffix=core.windows.net"


### PR DESCRIPTION
## Summary
- remove the unused `backend/.env.example` file

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687426d6fc40832b93616052f63bca84