### PR TITLE
Async report endpoints with error handling

### DIFF
--- a/backend/app/routers/report.py
+++ b/backend/app/routers/report.py
@@ -1,7 +1,7 @@
 import tempfile
 import os
 import json
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from ..utils.generate_report import generate_report
 from ..external_services import blob
 
@@ -9,23 +9,26 @@ router = APIRouter(prefix="/report", tags=["report"])
 
 
 @router.post("/")
-def create_report():
+async def create_report():
     with tempfile.TemporaryDirectory() as tmpdir:
         admin_path = os.path.join(tmpdir, "admin.xlsx")
         activity_path = os.path.join(tmpdir, "activity.xlsx")
         output_excel_path = os.path.join(tmpdir, "kodekloud_report.xlsx")
         output_json_path = os.path.join(tmpdir, "kodekloud_data.json")
 
-        blob.download_blob_to_file(
-            "cloudkit-inputs",
-            "kode_kloud/root/KodeKloud2025Admin.xlsx",
-            admin_path,
-        )
-        blob.download_blob_to_file(
-            "cloudkit-inputs",
-            "kode_kloud/root/activity_leaderboard.xlsx",
-            activity_path,
-        )
+        try:
+            blob.download_blob_to_file(
+                "cloudkit-inputs",
+                "kode_kloud/root/KodeKloud2025Admin.xlsx",
+                admin_path,
+            )
+            blob.download_blob_to_file(
+                "cloudkit-inputs",
+                "kode_kloud/root/activity_leaderboard.xlsx",
+                activity_path,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail="Failed to download blob") from exc
 
         data = generate_report(admin_path, activity_path, output_excel_path, output_json_path)
 
@@ -33,14 +36,17 @@ def create_report():
 
 
 @router.get("/data")
-def get_report_data():
+async def get_report_data():
     """Return the latest generated JSON report from Blob Storage."""
     with tempfile.TemporaryDirectory() as tmpdir:
         json_path = os.path.join(tmpdir, "kodekloud_data.json")
-        blob.download_blob_to_file(
-            "cloudkit-inputs",
-            "kode_kloud/root/kodekloud_data.json",
-            json_path,
-        )
+        try:
+            blob.download_blob_to_file(
+                "cloudkit-inputs",
+                "kode_kloud/root/kodekloud_data.json",
+                json_path,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail="Failed to download blob") from exc
         with open(json_path, "r") as f:
             return json.load(f)

--- a/backend/tests/test_report.py
+++ b/backend/tests/test_report.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_create_report_download_error(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise Exception("boom")
+
+    monkeypatch.setattr("app.routers.report.blob.download_blob_to_file", raise_error)
+
+    response = client.post("/report")
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to download blob"
+
+
+def test_get_report_data_download_error(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise Exception("boom")
+
+    monkeypatch.setattr("app.routers.report.blob.download_blob_to_file", raise_error)
+
+    response = client.get("/report/data")
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to download blob"


### PR DESCRIPTION
## Summary
- convert report endpoints to `async def`
- add `HTTPException` error handling when blob downloads fail
- test error cases for the report endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68742f9b37b8832b90de889566fbdcb3