### PR TITLE
Add report endpoint and utils unit tests

### DIFF
--- a/backend/tests/test_generate_report_utils.py
+++ b/backend/tests/test_generate_report_utils.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from app.utils.generate_report import convert_to_hours, merge_activity_data
+
+
+def test_convert_to_hours():
+    assert convert_to_hours("1 hour") == 1.0
+    assert convert_to_hours("30 minutes") == 0.5
+    assert convert_to_hours(2) == 2.0
+    assert convert_to_hours(None) == 0.0
+
+
+def test_merge_activity_data():
+    admin_df = pd.DataFrame(
+        {
+            "Name": ["Alice", "Bob"],
+            "Email": ["alice@example.com", "bob@example.com"],
+            "Program": ["Bootcamp", "Bootcamp"],
+            "License Accepted": ["Yes", "No"],
+        }
+    )
+    activity_df = pd.DataFrame(
+        {
+            "Email": ["alice@example.com", "bob@example.com"],
+            "Lessons Completed": [1, 0],
+            "Video Hours Watched": ["1 hour", "0"],
+            "Labs Completed": [0, 0],
+        }
+    )
+    result = merge_activity_data(admin_df, activity_df)
+    assert list(result.columns) == [
+        "Name",
+        "Email",
+        "Program",
+        "Lessons Completed",
+        "Video Hours Watched",
+        "Labs Completed",
+        "License Accepted",
+        "Status",
+    ]
+
+    bob = result[result["Email"] == "bob@example.com"].iloc[0]
+    assert bob["License Accepted"] == "X"
+    assert bob["Status"] == "No activity or progress"
+
+    alice = result[result["Email"] == "alice@example.com"].iloc[0]
+    assert alice["License Accepted"] == "\u2713"
+    assert alice["Status"] == ""

--- a/backend/tests/test_report.py
+++ b/backend/tests/test_report.py
@@ -1,5 +1,8 @@
 from fastapi.testclient import TestClient
 from main import app
+import pandas as pd
+import json
+import shutil
 
 client = TestClient(app)
 
@@ -24,3 +27,78 @@ def test_get_report_data_download_error(monkeypatch):
     response = client.get("/report/data")
     assert response.status_code == 500
     assert response.json()["detail"] == "Failed to download blob"
+
+
+def test_create_report_success(monkeypatch, tmp_path):
+    admin_df = pd.DataFrame(
+        {
+            "Name": ["Alice", "Bob"],
+            "Email": ["alice@example.com", "bob@example.com"],
+            "Program": ["Bootcamp", "Bootcamp"],
+            "License Accepted": ["Yes", "No"],
+        }
+    )
+    activity_df = pd.DataFrame(
+        {
+            "Email": ["alice@example.com", "bob@example.com"],
+            "Lessons Completed": [2, 0],
+            "Video Hours Watched": ["1 hour", 0],
+            "Labs Completed": [3, 0],
+        }
+    )
+    admin_src = tmp_path / "admin.xlsx"
+    activity_src = tmp_path / "activity.xlsx"
+    admin_df.to_excel(admin_src, index=False)
+    activity_df.to_excel(activity_src, index=False)
+
+    def fake_download(container, blob_name, local_path):
+        if "Admin" in blob_name:
+            shutil.copy(admin_src, local_path)
+        else:
+            shutil.copy(activity_src, local_path)
+
+    monkeypatch.setattr("app.routers.report.blob.download_blob_to_file", fake_download)
+    monkeypatch.setattr("app.utils.generate_report.blob.download_blob_to_file", fake_download)
+    monkeypatch.setattr("app.utils.generate_report.blob.upload_file_to_blob", lambda *a, **k: None)
+
+    response = client.post("/report")
+    assert response.status_code == 200
+    expected = [
+        {
+            "Name": "Alice",
+            "Email": "alice@example.com",
+            "Program": "Bootcamp",
+            "Lessons Completed": 2,
+            "Video Hours Watched": 1.0,
+            "Labs Completed": 3,
+            "License Accepted": "\u2713",
+            "Status": "",
+        },
+        {
+            "Name": "Bob",
+            "Email": "bob@example.com",
+            "Program": "Bootcamp",
+            "Lessons Completed": 0,
+            "Video Hours Watched": 0.0,
+            "Labs Completed": 0,
+            "License Accepted": "X",
+            "Status": "No activity or progress",
+        },
+    ]
+    assert response.json() == expected
+
+
+def test_get_report_data_success(monkeypatch, tmp_path):
+    data = [{"foo": "bar"}]
+    json_file = tmp_path / "kodekloud_data.json"
+    with open(json_file, "w") as f:
+        json.dump(data, f)
+
+    def fake_download(container, blob_name, local_path):
+        shutil.copy(json_file, local_path)
+
+    monkeypatch.setattr("app.routers.report.blob.download_blob_to_file", fake_download)
+
+    response = client.get("/report/data")
+    assert response.status_code == 200
+    assert response.json() == data


### PR DESCRIPTION
## Summary
- expand report endpoint test coverage with success cases
- mock blob storage interactions in tests
- add unit tests for generate_report utility functions

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743356c13c832b82316129906f906e