### PR TITLE
Add UUI NextJS global styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ curl -X POST http://localhost:8000/report
 - Added a new simplified React frontend under `frontend` that uses the
   `uui-theme-eduverse_dark` styles and shows report data in a table.
 - Added a Dockerfile and `nginx.conf` so the frontend can run via Docker Compose.
+- Imported global styles from the UUI Next.js template to enhance fonts and link appearance.
 
 ## 👤 Maintainer
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,3 +1,4 @@
+@import "./uui-nextjs-globals.scss";
 @import "../epam-template/epam-assets/theme/theme_eduverse_dark.scss";
 
 body {

--- a/frontend/src/uui-nextjs-globals.scss
+++ b/frontend/src/uui-nextjs-globals.scss
@@ -1,0 +1,21 @@
+html,
+body {
+    padding: 0;
+    margin: 0;
+    font-family: var(--uui-font, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif);
+}
+
+a {
+    color: #0070f3;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus,
+a:active {
+    text-decoration: underline;
+}
+
+* {
+    box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- incorporate global styles from the UUI Next.js template
- import the new stylesheet in the React app
- document new styles in README

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874f4817d8c832badf14a551be269af