### PR TITLE
Update container paths in workflow

### DIFF
--- a/.github/workflows/move_and_trigger.yml
+++ b/.github/workflows/move_and_trigger.yml
@@ -24,8 +24,8 @@ jobs:
         env:
           STORAGE_CONNECTION_STRING: ${{ secrets.STORAGE_CONNECTION_STRING }}
           TRIGGER_URL: ${{ secrets.TRIGGER_URL }}
-          CONTAINER_SOURCE: kodekloudfiles
+          CONTAINER_SOURCE: cloudkit-inputs
           CONTAINER_INPUTS: cloudkit-inputs
-          INPUT_FOLDER: input
-          ARCHIVE_FOLDER: archive
+          INPUT_FOLDER: kode_kloud/input
+          ARCHIVE_FOLDER: kode_kloud/input/archive
         run: python scripts/move_and_trigger.py

--- a/scripts/move_and_trigger_core.py
+++ b/scripts/move_and_trigger_core.py
@@ -5,10 +5,10 @@ from azure.storage.blob import BlobServiceClient
 
 # Config desde GitHub Secrets o entorno
 STORAGE_CONNECTION_STRING = os.getenv("STORAGE_CONNECTION_STRING")
-CONTAINER_SOURCE = os.getenv("CONTAINER_SOURCE", "kodekloudfiles")
+CONTAINER_SOURCE = os.getenv("CONTAINER_SOURCE", "cloudkit-inputs")
 CONTAINER_INPUTS = os.getenv("CONTAINER_INPUTS", "cloudkit-inputs")
-INPUT_FOLDER = os.getenv("INPUT_FOLDER", "input")
-ARCHIVE_FOLDER = os.getenv("ARCHIVE_FOLDER", "archive")
+INPUT_FOLDER = os.getenv("INPUT_FOLDER", "kode_kloud/input")
+ARCHIVE_FOLDER = os.getenv("ARCHIVE_FOLDER", "kode_kloud/input/archive")
 TRIGGER_URL = os.getenv("TRIGGER_URL")
 
 blob_service_client = BlobServiceClient.from_connection_string(STORAGE_CONNECTION_STRING)


### PR DESCRIPTION
## Summary
- adjust defaults for new cloudkit container layout
- update workflow variables to match `cloudkit-inputs` paths

## Testing
- `pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875231539ac832b84fd17c05def010b