### PR TITLE
Fix JSON report path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a real-time dashboard that tracks the usage of KodeKloud license
 
 ## 🧩 Components
 
-- **Azure Blob Storage**: Stores input Excel files (`kode_kloud/root/KodeKloud2025Admin.xlsx`, `kode_kloud/root/activity_leaderboard.xlsx`) and output JSON (`kodekloud_data.json`).
+- **Azure Blob Storage**: Stores input Excel files (`kode_kloud/root/KodeKloud2025Admin.xlsx`, `kode_kloud/root/activity_leaderboard.xlsx`) and output JSON (`kode_kloud/root/kodekloud_data.json`).
 - **FastAPI Backend**: Triggered via HTTP, processes the Excel files and generates a report in Excel and JSON formats.
 - **GitHub Actions**:
   - One workflow generates the JSON report by calling the FastAPI backend.

--- a/backend/app/routers/report.py
+++ b/backend/app/routers/report.py
@@ -4,6 +4,7 @@ import json
 from fastapi import APIRouter, HTTPException
 from ..utils.generate_report import generate_report
 from ..external_services import blob
+from ..core import settings
 
 router = APIRouter(prefix="/report", tags=["KodeKloud"])
 
@@ -18,13 +19,13 @@ async def create_report():
 
         try:
             blob.download_blob_to_file(
-                "cloudkit-inputs",
-                "kode_kloud/root/KodeKloud2025Admin.xlsx",
+                settings.CONTAINER_INPUTS,
+                settings.ADMIN_BLOB_PATH,
                 admin_path,
             )
             blob.download_blob_to_file(
-                "cloudkit-inputs",
-                "kode_kloud/root/activity_leaderboard.xlsx",
+                settings.CONTAINER_INPUTS,
+                settings.ACTIVITY_BLOB_PATH,
                 activity_path,
             )
         except Exception as exc:
@@ -42,8 +43,8 @@ async def get_report_data():
         json_path = os.path.join(tmpdir, "kodekloud_data.json")
         try:
             blob.download_blob_to_file(
-                "cloudkit-inputs",
-                "kode_kloud/root/kodekloud_data.json",
+                settings.CONTAINER_INPUTS,
+                settings.JSON_BLOB_PATH,
                 json_path,
             )
         except Exception as exc:

--- a/backend/app/utils/generate_report.py
+++ b/backend/app/utils/generate_report.py
@@ -10,6 +10,7 @@ from openpyxl import load_workbook
 from openpyxl.styles import PatternFill
 
 from ..external_services import blob
+from ..core import settings
 
 warnings.simplefilter("ignore")
 
@@ -126,8 +127,8 @@ def upload_json(local_json_path: str) -> None:
     """Upload the JSON file to Azure Blob Storage."""
 
     blob.upload_file_to_blob(
-        "cloudkit-inputs",
-        local_json_path.split("/")[-1],
+        settings.CONTAINER_INPUTS,
+        settings.JSON_BLOB_PATH,
         local_json_path,
     )
 


### PR DESCRIPTION
## Summary
- upload JSON to `kode_kloud/root/kodekloud_data.json`
- use settings constants for blob paths in the router
- clarify README about JSON location

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68753b512074832b97e20100c5c84a51